### PR TITLE
Refactor: 사용자 로그인 로직 수정, redux user State props 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["img.youtube.com"],
+    domains: ["img.youtube.com", "k.kakaocdn.net"],
   },
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -94,18 +94,4 @@ function MyApp({ Component, pageProps }: AppProps) {
   );
 }
 
-MyApp.getInitialProps = async (context: AppContext) => {
-  const { ctx } = context;
-  const allCookies = cookies(ctx);
-
-  const accessTokenByCookie = allCookies[config.cookieAuthHeaderKey];
-  if (accessTokenByCookie) {
-    axios.defaults.headers.common[config.authHeaderKey] = accessTokenByCookie;
-  }
-
-  const appProps = await App.getInitialProps(context);
-
-  return { ...appProps, props: accessTokenByCookie };
-};
-
 export default wrapper.withRedux(MyApp);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,14 +31,14 @@ const Home: NextPage<Props> = ({ token }) => {
     }
   }, []);
 
-  useEffect(() => {
-    if (token && !isLoggedIn) {
-      console.log('login');
-      const response = axios.get('/api/profile');
-      dispatch(userActions.login({ token: token, socialType: 'kakao' }));
-      console.log(response);
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (token && !isLoggedIn) {
+  //     console.log('login');
+  //     const response = axios.get('/api/profile');
+  //     dispatch(userActions.login({ token: token, socialType: 'kakao' }));
+  //     console.log(response);
+  //   }
+  // }, []);
 
   return (
     <Layout title='홈'>

--- a/pages/oauth/redirect.tsx
+++ b/pages/oauth/redirect.tsx
@@ -6,39 +6,24 @@ import cookies from 'next-cookies';
 import { GetServerSideProps, NextPage } from 'next';
 
 import config from 'utils/config';
+import Router from 'next/router';
 
-interface Props {
-  token: string;
-}
-
-const OauthRedirectPage: NextPage<Props> = ({ token }) => {
+const OauthRedirectPage: NextPage = () => {
   const dispatch = useDispatch();
 
+  // useEffect(() => {
+  //   console.log(token);
+  //   if (typeof token === 'string') {
+  //     const response = axios.get('/get/user');
+  //     dispatch(userActions.login({ token: token, socialType: 'kakao' }));
+  //     console.log(response);
+  //   }
+  // }, [token, dispatch]);
   useEffect(() => {
-    console.log(token);
-    if (typeof token === 'string') {
-      const response = axios.get('/get/user');
-      dispatch(userActions.login({ token: token, socialType: 'kakao' }));
-      console.log(response);
-    }
-  }, [token, dispatch]);
+    Router.push('/');
+  });
 
   return <div>Loading...</div>;
-};
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const allCookies = cookies(context);
-
-  const accessTokenByCookie = allCookies[config.cookieAuthHeaderKey];
-  if (accessTokenByCookie) {
-    axios.defaults.headers.common[config.authHeaderKey] = accessTokenByCookie;
-  }
-
-  return {
-    props: {
-      token: accessTokenByCookie,
-    },
-  };
 };
 
 export default OauthRedirectPage;

--- a/pages/profile/ProfileAvatar.tsx
+++ b/pages/profile/ProfileAvatar.tsx
@@ -14,18 +14,8 @@ const ProfileAvatar: React.FC<Props> = ({ avatarSrc, isEdit = false }) => {
           <label className='editButton' htmlFor='profileUpload'>
             <Image src='/btn_edit.svg' layout='fill' alt='edit-button' />
           </label>
-          <input
-            className='input'
-            name='profileUpload'
-            accept='image/*'
-            type='hidden'
-          />
-          <input
-            className='input'
-            name='thumbnailName'
-            value={avatarSrc}
-            type='hidden'
-          />
+          <input className='input' name='profileUpload' accept='image/*' type='hidden' />
+          <input className='input' name='thumbnailName' value={avatarSrc} type='hidden' />
         </>
       )}
       <style jsx>
@@ -36,6 +26,7 @@ const ProfileAvatar: React.FC<Props> = ({ avatarSrc, isEdit = false }) => {
             border-radius: 50%;
             width: 180px;
             height: 180px;
+            overflow: hidden;
           }
           .editButton {
             position: absolute;

--- a/pages/profile/edit/index.tsx
+++ b/pages/profile/edit/index.tsx
@@ -16,8 +16,8 @@ import { HEADER_HEIGHT } from 'components/Layout';
 
 const ProfileEditPage: NextPage = () => {
   const dispatch = useDispatch();
-  const { nickName, userAvatar } = useSelector((state: AppState) => state.user);
-  const [avatarSrc, setAvatarSrc] = useState<string>(userAvatar);
+  const { user } = useSelector((state: AppState) => state.user);
+  const [avatarSrc, setAvatarSrc] = useState<string>(user.avatar);
   const formRef = useRef<HTMLFormElement>(null);
 
   const { editType } = useRouter().query;
@@ -61,7 +61,7 @@ const ProfileEditPage: NextPage = () => {
     >
       <form className='profileWrapper' ref={formRef}>
         <ProfileAvatar isEdit  avatarSrc={avatarSrc} />
-        <ProfileInfo isEdit name={nickName} />
+        <ProfileInfo isEdit name={user.nickName} />
       </form>
       <style jsx>{profileWrapper}</style>
       <style jsx>

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -30,7 +30,7 @@ const ProfilePage = () => {
   // useUserTypeRedirect('/', 'guest');
   const dispatch = useDispatch();
   const [showConfirm, setConfirm] = useState(false);
-  const { userEmail, nickName, userAvatar, token } = useUserState();
+  const { user , token } = useUserState();
 
   const logoutRequest = async () => {
     await axios
@@ -77,8 +77,8 @@ const ProfilePage = () => {
   return (
     <Layout>
       <div className='profileWrapper'>
-        <ProfileAvatar avatarSrc={userAvatar} />
-        <ProfileInfo name={nickName} email={userEmail} />
+        <ProfileAvatar avatarSrc={user.avatar} />
+        <ProfileInfo name={user.nickName} email={user.email} />
         <div className='buttonWrapper'>
           <Button
             onClick={() => {

--- a/store/user.ts
+++ b/store/user.ts
@@ -4,23 +4,30 @@ import { deleteCookie } from 'utils/cookie';
 import axios from 'axios';
 import config from 'utils/config';
 
-export interface User {
-  isLoggedIn: boolean;
-  userID: string;
-  userEmail: string;
+export type LoginUser = {
+  id: string;
+  email: string;
   nickName: string;
-  userAvatar: string;
+  avatar: string;
+};
+
+export interface UserState {
+  user: LoginUser;
+  isLoggedIn: boolean;
   token: string;
 }
 
 export type SocialType = 'kakao' | 'google';
-
-const initialState: User = {
-  isLoggedIn: false,
-  userID: '',
-  userEmail: '',
+const initLoginUser: LoginUser = {
+  id: '',
+  email: '',
   nickName: '',
-  userAvatar: '',
+  avatar: '',
+};
+
+const initialState: UserState = {
+  isLoggedIn: false,
+  user: initLoginUser,
   token: '',
 };
 
@@ -34,46 +41,22 @@ const userSlice = createSlice({
         token: action.payload.token,
       };
     },
-    loadUser: (
-      state,
-      action: PayloadAction<{
-        userID: string;
-        nickName: string;
-        userAvatar: string;
-        userEmail: string;
-      }>
-    ) => {
-      const { userID, userEmail, nickName, userAvatar = 'defaultAvatar' } = action.payload;
-      return {
-        ...state,
-        userEmail: userEmail,
-        isLoggedIn: true,
-        userID: userID,
-        nickName: nickName,
-        userAvatar: userAvatar,
-      };
-    },
     login: (
       state,
       action: PayloadAction<{
         token: string;
+        loginUser: LoginUser;
         socialType: SocialType;
       }>
     ) => {
-      const { token } = action.payload;
+      const { token, loginUser } = action.payload;
       //todo token으로 서버에  user data 요청
       //response 상태에 따라 회원가입 페이지, or 홈페이지로 이동해야함
-
-      //일단 서버측에서 구현된 유저데이터 response가 없으므로 mockData 추가
-      //response 성공시 홈으로 redirect
       Router.push('/');
       return {
         ...state,
-        userEmail: 'whatzmock@mock.com',
         isLoggedIn: true,
-        userAvatar: '/profile.png',
-        userID: 'userid',
-        nickName: 'Whatz개발',
+        user: loginUser,
         token: token,
       };
     },


### PR DESCRIPTION
- 기존 next-cookie를 사용해 로그인하던 로직에서 tab-bar 컴포넌트에서 로그인하는 로직으로 수정-
- userState interface 수정 
```
export type LoginUser = {
  id: string;
  email: string;
  nickName: string;
  avatar: string;
};

export interface UserState {
  user: LoginUser;
  isLoggedIn: boolean;
  token: string;
}
```